### PR TITLE
Move `from typing import List` to top-level

### DIFF
--- a/src/sphinx_theme_builder/_internal/passthrough.py
+++ b/src/sphinx_theme_builder/_internal/passthrough.py
@@ -33,6 +33,7 @@ which in turn was adapted from StackOverflow.
 """
 
 import sys
+from typing import List
 
 if sys.platform != "win32":
     import errno
@@ -45,7 +46,6 @@ if sys.platform != "win32":
     from itertools import chain
     from select import select
     from subprocess import Popen
-    from typing import List
 
     (_COLUMNS, _ROWS) = shutil.get_terminal_size(fallback=(80, 20))
 


### PR DESCRIPTION
The `win32` platform requires an import of `List` for its `passthrough_run` definition. Moving the import from the non-Windows platform to any platform.