### PR TITLE
MAINT: Add log if package-lock.json doesn't exist

### DIFF
--- a/docs/reference/build-process.md
+++ b/docs/reference/build-process.md
@@ -4,3 +4,22 @@
 Describe how the theme source tree -> distribution process works. Note
 the knobs that the theme authors have in it.
 ```
+
+## Using `package-lock.json`
+
+By default, this tool does not generate a `package-lock.json` when you install
+your Node environment. This avoids unexpected changes to the package lockfile.
+
+However, it is strongly encouraged to generate a `package-lock.json` file in
+order to stabilize the JavaScript versions that are installed when somebody
+builds your theme locally.
+
+To do so, run the following command after installing this theme locally for the
+first time:
+
+```
+stb npm install --include=dev
+```
+
+This will generate a `package-lock.json` file that you can check in to your
+repository.

--- a/src/sphinx_theme_builder/_internal/nodejs.py
+++ b/src/sphinx_theme_builder/_internal/nodejs.py
@@ -135,6 +135,11 @@ def create_nodeenv(nodeenv: Path, node_version: str) -> None:
 
 def run_npm_build(nodeenv: Path, *, production: bool) -> None:
     try:
+        if not Path(".package-json.lock").exists():
+            log(
+                "[yellow]#[/] Did not find [magenta]package-lock.json[/]. To add "
+                "one, run [cyan]stb npm install --include=dev[/]."
+            )
         run_in(nodeenv, ["npm", "run-script", "build"], production=production)
     except subprocess.CalledProcessError as error:
         raise DiagnosticError(


### PR DESCRIPTION
This adds a short warning if `package-lock.json` doesn't exist. My rationale for adding it where I did is the following:

- When you install node for the first time, this is the only time that `npm install` is run.
- If you remove `--no-save` here, then whenever a person installs via the theme builder for the first time, it'd overwrite `package-lock.json` which will be confusing for reasons described in https://github.com/pradyunsg/sphinx-theme-builder/issues/14
- So, emit a warning when you **compile** with `stb` that tells the user what command to run to create this file.
- That way, the act of creating or updating that file will always be an intentional step.

closes #14