### PR TITLE
Add optional --host argument to serve

### DIFF
--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -19,6 +19,10 @@ The Sphinx builder to build the documentation with.
 
 Allowed values: `html` (default), `dirhtml`
 
+### `--host`
+
+hostname to serve documentation on (default: 127.0.0.1)
+
 ### `--port`
 
 The port to start the server on. Uses a random free port by default.

--- a/src/sphinx_theme_builder/_internal/cli/serve.py
+++ b/src/sphinx_theme_builder/_internal/cli/serve.py
@@ -25,6 +25,13 @@ class ServeCommand:
             help="The Sphinx builder to build the documentation with",
         ),
         click.Option(
+            ["--host"],
+            default=None,
+            show_default=True,
+            show_choices=True,
+            help="hostname to serve documentation on (default: 127.0.0.1)",
+        ),
+        click.Option(
             ["--port"],
             type=click.INT,
             default=0,
@@ -67,6 +74,7 @@ class ServeCommand:
     def run(
         self,
         *,
+        host: str,
         port: int,
         source_directory: Path,
         builder: str,
@@ -84,6 +92,7 @@ class ServeCommand:
                 # sphinx-autobuild flags
                 f"--watch={os.fsdecode(project.source_path)}",
                 f"--re-ignore=({'|'.join(map(re.escape, project.compiled_assets))})",
+                f"{f'--host={host}' if host else ''}",
                 f"--port={port}",  # use a random free port
                 f"--pre-build='{sys.executable}' -m sphinx_theme_builder compile",
                 # Sphinx flags

--- a/src/sphinx_theme_builder/_internal/cli/serve.py
+++ b/src/sphinx_theme_builder/_internal/cli/serve.py
@@ -92,7 +92,6 @@ class ServeCommand:
                 # sphinx-autobuild flags
                 f"--watch={os.fsdecode(project.source_path)}",
                 f"--re-ignore=({'|'.join(map(re.escape, project.compiled_assets))})",
-                f"{f'--host={host}' if host else ''}",
                 f"--port={port}",  # use a random free port
                 f"--pre-build='{sys.executable}' -m sphinx_theme_builder compile",
                 # Sphinx flags
@@ -102,6 +101,8 @@ class ServeCommand:
                 os.fsdecode(source_directory),
                 os.fsdecode(build_directory),
             ]
+            if host:
+                command.append(f"--host={host}")
             if pdb:
                 command.append("-P")
             if open_browser:


### PR DESCRIPTION
This change is needed to be able to open documentation in a browser when running `stb serve` within a Docker container.