### PR TITLE
fix windows encoding

### DIFF
--- a/src/sphinx_theme_builder/_internal/distributions.py
+++ b/src/sphinx_theme_builder/_internal/distributions.py
@@ -127,9 +127,13 @@ def generate_metadata(
         ) from error
 
     # Delegated generation.
-    (dist_info / "entry_points.txt").write_text(project.get_entry_points_contents())
-    (dist_info / "LICENSE").write_text(project.get_license_contents())
-    (dist_info / "METADATA").write_text(project.get_metadata_file_contents())
+    (dist_info / "entry_points.txt").write_text(
+        project.get_entry_points_contents(), encoding="utf-8"
+    )
+    (dist_info / "LICENSE").write_text(project.get_license_contents(), encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        project.get_metadata_file_contents(), encoding="utf-8"
+    )
 
     # Templated generation.
     (dist_info / "WHEEL").write_text(
@@ -140,7 +144,8 @@ def generate_metadata(
             Root-Is-Purelib: true
             Tag: py3-none-any
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     return dist_info.name


### PR DESCRIPTION
```text
        File "C:\Users\Trim21\proj\furo\.venv\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
          main()
        File "C:\Users\Trim21\proj\furo\.venv\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "C:\Users\Trim21\proj\furo\.venv\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 181, in prepare_metadata_for_build_editable
          return hook(metadata_directory, config_settings)
        File "C:\Users\Trim21\AppData\Local\Temp\pip-build-env-mz9nqtpo\overlay\Lib\site-packages\sphinx_theme_builder\__init__.py", line 80, in prepare_metadata_for_build_wheel 
          return _generate_metadata(project, destination=Path(metadata_directory))
        File "C:\Users\Trim21\AppData\Local\Temp\pip-build-env-mz9nqtpo\overlay\Lib\site-packages\sphinx_theme_builder\_internal\distributions.py", line 132, in generate_metadata
          (dist_info / "METADATA").write_text(project.get_metadata_file_contents())
        File "C:\Users\Trim21\scoop\apps\python310\3.10.11\lib\pathlib.py", line 1155, in write_text
          return f.write(data)

```