### PR TITLE
Fix --re-ignore

### DIFF
--- a/src/sphinx_theme_builder/_internal/cli/serve.py
+++ b/src/sphinx_theme_builder/_internal/cli/serve.py
@@ -37,7 +37,7 @@ class ServeCommand:
             default="",
             show_default=True,
             show_choices=True,
-            help="Text passed to `sphinx-build` option `--re-ignore`, parsed as a regular expression.",
+            help="Text passed to `sphinx_autobuild` option `--re-ignore`, parsed as a regular expression.",
         ),
         click.Option(
             ["--port"],

--- a/src/sphinx_theme_builder/_internal/cli/serve.py
+++ b/src/sphinx_theme_builder/_internal/cli/serve.py
@@ -94,7 +94,7 @@ class ServeCommand:
         project = Project.from_cwd()
 
         default_re_ignore = f"{'|'.join(map(re.escape, project.compiled_assets))}"
-        re_ignore = f"{'|'.join((re.escape(re_ignore), default_re_ignore))}"
+        re_ignore = f"{'|'.join((re_ignore, default_re_ignore))}"
 
         with tempfile.TemporaryDirectory() as build_directory:
             command = [


### PR DESCRIPTION
This PR does 2 things:

1. correct the help text for the `--re-ignore` arg to `stb serve` (introduced in #41)
2. removes the `re.escape` around the user-passed regex, so that users can do things like `session.run("stb", "serve", "docs", "--re-ignore=locale|api")` (noxfile) or `stb serve docs --re-ignore=locale\|api` (command line) and not have the `|` in `locale|api` get escaped

crossref: https://github.com/pydata/pydata-sphinx-theme/issues/1359