### PR TITLE
Fix filepaths and use underscores

### DIFF
--- a/docs/filesystem-layout.md
+++ b/docs/filesystem-layout.md
@@ -18,7 +18,7 @@ quality-of-life things like `stb serve`.
         - __init__.py
         - [other Python files]
         - theme: # HTML templates
-            - my_amazing_theme:
+            - my-amazing-theme:
                 - [various .html pages]
                 - static - [any static assets that don't need to be compiled,
                   like images]
@@ -49,9 +49,9 @@ compiled. Add them to the project's `.gitignore`:
   theme's assets.
 - `node_modules` - The NodeJS packages that are installed for use, to compile
   the theme's assets.
-- `src/<my_amazing_theme>/theme/<my_amazing_theme>/static/styles` - The compiled CSS assets for the
+- `src/<my_amazing_theme>/theme/<my-amazing-theme>/static/styles` - The compiled CSS assets for the
   theme
-- `src/<my_amazing_theme>/theme/<my_amazing_theme>/static/scripts` - The compiled JS assets for the
+- `src/<my_amazing_theme>/theme/<my-amazing-theme>/static/scripts` - The compiled JS assets for the
   theme
 
 ## How to get this right

--- a/docs/filesystem-layout.md
+++ b/docs/filesystem-layout.md
@@ -18,7 +18,7 @@ quality-of-life things like `stb serve`.
         - __init__.py
         - [other Python files]
         - theme: # HTML templates
-            - my-amazing-theme:
+            - my_amazing_theme:
                 - [various .html pages]
                 - static - [any static assets that don't need to be compiled,
                   like images]
@@ -49,9 +49,9 @@ compiled. Add them to the project's `.gitignore`:
   theme's assets.
 - `node_modules` - The NodeJS packages that are installed for use, to compile
   the theme's assets.
-- `src/theme/<my-awesome-theme>/static/styles` - The compiled CSS assets for the
+- `src/<my_amazing_theme>/theme/<my_amazing_theme>/static/styles` - The compiled CSS assets for the
   theme
-- `src/theme/<my-awesome-theme>/static/scripts` - The compiled JS assets for the
+- `src/<my_amazing_theme>/theme/<my_amazing_theme>/static/scripts` - The compiled JS assets for the
   theme
 
 ## How to get this right


### PR DESCRIPTION
Using dashes in a directory that Sphinx reads caused me problems, so I went with underscores.

Additionally the path names were incorrect and mismatched against the name of the project.

This PR corrects both issues.