### PR TITLE
Avoid ast.Str for python 3.14 compatibility

### DIFF
--- a/src/sphinx_theme_builder/_internal/project.py
+++ b/src/sphinx_theme_builder/_internal/project.py
@@ -40,9 +40,10 @@ def get_version_using_ast(contents: bytes) -> Optional[str]:
             and len(child.targets) == 1
             and isinstance(child.targets[0], ast.Name)
             and child.targets[0].id == "__version__"
-            and isinstance(child.value, ast.Str)
+            and isinstance(child.value, ast.Constant)
+            and isinstance(child.value.value, str)
         ):
-            version = child.value.s
+            version = child.value.value
             break
 
     return version


### PR DESCRIPTION
`ast.Str` was deprecated in python 3.8 and has been removed completely in prereleases of python 3.14.  This change avoids use of the removed API.  In consequence, however, you would have to drop python 3.7 support to merge this.